### PR TITLE
Make extension checking in library scans robust

### DIFF
--- a/src/Services/library.service.ts
+++ b/src/Services/library.service.ts
@@ -100,7 +100,7 @@ export class LibraryService {
 			mkdirSync(process.env.ART_PATH || "art");
 		}
 
-		const files = await this.get_files(path).filter((file) => ext.some((e) => file.includes(e)));
+		const files = await this.get_files(path).filter((file) => ext.some((e) => file.split('.').pop().includes(e)));
 
 		const start = new Date();
 		await this.extractMetadata(files);


### PR DESCRIPTION
Ended up getting errors about the music-metadata library not being able to read a file with extension '.png' and it turned out that I have an image with 'mp3' in it. This doesn't seem like that unlikely of a case so I propose we check the extension portion of the filename rather than the whole filename for the extension we are looking for.