### PR TITLE
fix(metadata): use try/catch with async/await instead of chaining .catch

### DIFF
--- a/src/Services/library.service.ts
+++ b/src/Services/library.service.ts
@@ -111,7 +111,13 @@ export class LibraryService {
 				continue;
 			}
 
-			const metadata: any = await mm.parseFile(file).catch((err) => console.log("Failed to parse", file, err));
+			let metadata: any = null;
+			try {
+				metadata = await mm.parseFile(file);
+			} catch (err) {
+				console.log("Failed to parse", file, err);
+				continue;
+			}
 
 			if (!metadata) {
 				console.log(`No metadata found for file: ${file}`);


### PR DESCRIPTION
I believe this fixes this issue: https://github.com/Wellenline/waveline-server/issues/14

It should just continue if the parsing failed instead of throwing an exception.